### PR TITLE
Fix for PHP 8

### DIFF
--- a/sync.c
+++ b/sync.c
@@ -33,6 +33,15 @@
 #define PHP_FE_END {NULL, NULL, NULL}
 #endif
 
+/* for PHP 8 */
+#ifndef TSRMLS_D
+#define TSRMLS_D void
+#define TSRMLS_DC
+#define TSRMLS_C
+#define TSRMLS_CC
+#define TSRMLS_FETCH()
+#endif
+
 /* {{{ sync_module_entry
  */
 zend_module_entry sync_module_entry = {


### PR DESCRIPTION
```
PHP         : /opt/remi/php80/root/usr/bin/php 
PHP_SAPI    : cli
PHP_VERSION : 8.0.0
ZEND_VERSION: 4.0.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 5.9.11-200.fc33.x86_64 #1 SMP Tue Nov 24 18:18:01 UTC 2020 x86_64
INI actual  : /work/GIT/pecl-and-ext/sync/tmp-php.ini
More .INIs  :   
---------------------------------------------------------------------
PHP         : /opt/remi/php80/root/usr/bin/phpdbg 
PHP_SAPI    : phpdbg
PHP_VERSION : 8.0.0
ZEND_VERSION: 4.0.0-dev
PHP_OS      : Linux - Linux builder.remirepo.net 5.9.11-200.fc33.x86_64 #1 SMP Tue Nov 24 18:18:01 UTC 2020 x86_64
INI actual  : /work/GIT/pecl-and-ext/sync/tmp-php.ini
More .INIs  : 
---------------------------------------------------------------------
CWD         : /work/GIT/pecl-and-ext/sync
Extra dirs  : 
VALGRIND    : Not used
=====================================================================
TIME START 2020-12-10 09:56:35
=====================================================================
PASS Check for sync presence [tests/001.phpt] 
PASS SyncMutex - unnamed mutex allocation, locking, and unlocking. [tests/002.phpt] 
PASS SyncMutex - named mutex allocation, locking, and unlocking. [tests/003.phpt] 
PASS SyncSemaphore (1) - unnamed semaphore allocation, locking, and unlocking. [tests/004.phpt] 
PASS SyncSemaphore (2) - unnamed semaphore allocation, locking, and unlocking. [tests/005.phpt] 
PASS SyncSemaphore (1) - named semaphore allocation, locking, and unlocking. [tests/006.phpt] 
PASS SyncSemaphore (2) - named semaphore allocation, locking, and unlocking. [tests/007.phpt] 
PASS SyncEvent - unnamed automatic event object allocation and firing. [tests/008.phpt] 
PASS SyncEvent - named automatic event object allocation and firing. [tests/009.phpt] 
PASS SyncEvent - unnamed manual event object allocation and firing. [tests/010.phpt] 
PASS SyncEvent - named manual event object allocation and firing. [tests/011.phpt] 
PASS SyncReaderWriter - unnamed reader-writer allocation, locking, and unlocking. [tests/012.phpt] 
PASS SyncReaderWriter - named reader-writer allocation, locking, and unlocking. [tests/013.phpt] 
PASS SyncReaderWriter - named reader-writer allocation, locking, and unlocking freeze test. [tests/014.phpt] 
PASS SyncSharedMemory - named shared memory allocation, size, reading, and writing test. [tests/015.phpt] 
PASS SyncSharedMemory - named shared memory allocation reuse test. [tests/016.phpt] 
=====================================================================
TIME END 2020-12-10 09:56:36

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   16
---------------------------------------------------------------------

Number of tests :   16                16
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :   16 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    1 seconds
=====================================================================

```